### PR TITLE
Feature/versioning

### DIFF
--- a/launch/__init__.py
+++ b/launch/__init__.py
@@ -1,6 +1,7 @@
 from semver import Version
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
+
 SEMANTIC_VERSION = Version.parse(VERSION)
 GITHUB_ORG_NAME = "nexient-llc"
 GITHUB_REPO_NAME = "launch-cli"

--- a/launch/__init__.py
+++ b/launch/__init__.py
@@ -1,0 +1,4 @@
+from semver import Version
+
+VERSION = "0.1.0"
+SEMANTIC_VERSION = Version.parse(VERSION)

--- a/launch/__init__.py
+++ b/launch/__init__.py
@@ -2,3 +2,5 @@ from semver import Version
 
 VERSION = "0.1.0"
 SEMANTIC_VERSION = Version.parse(VERSION)
+GITHUB_ORG_NAME = "nexient-llc"
+GITHUB_REPO_NAME = "launch-cli"

--- a/launch/cli/entrypoint.py
+++ b/launch/cli/entrypoint.py
@@ -40,7 +40,7 @@ def cli(context: click.core.Context, verbose: bool, version: bool):
         format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
         datefmt="%F %T %Z",
     )
-
+    # breakpoint()
     if UPDATE_CHECK and not context.invoked_subcommand == "pipeline":
         new_version = check_for_updates(include_prerelease=UPDATE_ALLOW_PRERELEASE)
         if new_version:

--- a/launch/cli/entrypoint.py
+++ b/launch/cli/entrypoint.py
@@ -10,6 +10,7 @@ from launch.update import check_for_updates
 
 @click.command("version")
 def get_version():
+    """Prints the current version of the tool and immediately exits"""
     from launch import SEMANTIC_VERSION
 
     logging.info(f"Launch CLI Version {SEMANTIC_VERSION}")

--- a/launch/cli/entrypoint.py
+++ b/launch/cli/entrypoint.py
@@ -1,9 +1,10 @@
 import logging
+import sys
 
 import click
 
 
-@click.group(name="cli")
+@click.group(name="cli", invoke_without_command=True)
 @click.option(
     "--verbose",
     "-v",
@@ -12,13 +13,25 @@ import click
     default=False,
     help="Increase verbosity of all subcommands",
 )
-def cli(verbose):
+@click.option(
+    "--version",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Prints the current version of the tool and immediately exits.",
+)
+def cli(verbose, version):
     """Launch CLI tooling to help automate common tasks performed by Launch engineers and their clients."""
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
         datefmt="%F %T %Z",
     )
+    if version:
+        from launch import SEMANTIC_VERSION
+
+        logging.info(f"Launch CLI Version {SEMANTIC_VERSION}")
+        sys.exit(0)
 
 
 from .github import github_group

--- a/launch/cli/entrypoint.py
+++ b/launch/cli/entrypoint.py
@@ -1,7 +1,19 @@
 import logging
+import os
 import sys
 
 import click
+
+from launch.env import UPDATE_ALLOW_PRERELEASE, UPDATE_CHECK
+from launch.update import check_for_updates
+
+
+@click.command("version")
+def get_version():
+    from launch import SEMANTIC_VERSION
+
+    logging.info(f"Launch CLI Version {SEMANTIC_VERSION}")
+    sys.exit(0)
 
 
 @click.group(name="cli", invoke_without_command=True)
@@ -20,20 +32,32 @@ import click
     default=False,
     help="Prints the current version of the tool and immediately exits.",
 )
-def cli(verbose, version):
+@click.pass_context
+def cli(context: click.core.Context, verbose: bool, version: bool):
     """Launch CLI tooling to help automate common tasks performed by Launch engineers and their clients."""
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
         datefmt="%F %T %Z",
     )
-    if version:
-        from launch import SEMANTIC_VERSION
 
-        logging.info(f"Launch CLI Version {SEMANTIC_VERSION}")
-        sys.exit(0)
+    if UPDATE_CHECK and not context.invoked_subcommand == "pipeline":
+        new_version = check_for_updates(include_prerelease=UPDATE_ALLOW_PRERELEASE)
+        if new_version:
+            click.secho(
+                f"Version {new_version} of Launch-CLI is now available!", fg="yellow"
+            )
+            click.secho(
+                "To install the latest version, execute the following command: "
+            )
+            click.secho("    pip install --update launch-cli", fg="yellow")
+    if context.invoked_subcommand is None and not version:
+        click.echo(cli.get_help(context))
+    if version:
+        context.invoke(get_version)
 
 
 from .github import github_group
 
+cli.add_command(get_version)
 cli.add_command(github_group)

--- a/launch/cli/github/access/commands.py
+++ b/launch/cli/github/access/commands.py
@@ -2,6 +2,7 @@ import logging
 
 import click
 
+from launch import GITHUB_ORG_NAME
 from launch.github.access import (
     NoMatchingTeamException,
     configure_default_branch_protection,
@@ -17,8 +18,8 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option(
     "--organization",
-    default="nexient-llc",
-    help="GitHub organization containing your repository. Defaults to the nexient-llc organization.",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization containing your repository. Defaults to the {GITHUB_ORG_NAME} organization.",
 )
 @click.option(
     "--repository-name", required=True, help="Name of the repository to be updated."

--- a/launch/cli/github/hooks/commands.py
+++ b/launch/cli/github/hooks/commands.py
@@ -2,6 +2,7 @@ import json
 
 import click
 
+from launch import GITHUB_ORG_NAME
 from launch.github.auth import get_github_instance
 from launch.github.hooks import create_hook
 
@@ -9,8 +10,8 @@ from launch.github.hooks import create_hook
 @click.command()
 @click.option(
     "--organization",
-    default="nexient-llc",
-    help="GitHub organization containing your repository. Defaults to the nexient-llc organization.",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization containing your repository. Defaults to the {GITHUB_ORG_NAME} organization.",
 )
 @click.option(
     "--repository-name", required=True, help="Name of the repository to be updated."

--- a/launch/env.py
+++ b/launch/env.py
@@ -1,0 +1,46 @@
+import os
+
+
+def strtobool(value: str) -> bool:
+    """Turns a truthy or falsy case-insensitive string into a boolean. Previously this was provided by distutils, but that has been deprecated.
+
+    Args:
+        value (str): Input value to turn into a boolean.
+
+    Raises:
+        ValueError: Raised if the input string isn't one of our recognized truthy or falsy values.
+
+    Returns:
+        bool: Result of determining truthiness or falsiness.
+    """
+    value = str(value)
+    truthy_values = ["y", "yes", "t", "true", "on", "1"]
+    falsy_values = ["n", "no", "f", "false", "off", "0"]
+    if value.lower() in truthy_values:
+        return True
+    elif value.lower() in falsy_values:
+        return False
+    else:
+        raise ValueError(
+            f"Provided string '{value}' was not valid! Must be one of {truthy_values + falsy_values}"
+        )
+
+
+def get_bool_env_var(env_var_name: str, default_value: bool) -> bool:
+    """Gets a value from an environment variable if it is set, and returns the default_value otherwise.
+
+    Args:
+        env_var_name (str): Name of the environment variable to pull from.
+        default_value (bool): Replacement value if the environment variable is not set.
+
+    Raises:
+        ValueError: Raises from internal comparison if the value in the environment variable isn't one of our recognized truthy or falsy values.
+
+    Returns:
+        bool: Result of determining truthiness or falsiness.
+    """
+    return strtobool(os.environ.get(env_var_name, default=default_value))
+
+
+UPDATE_CHECK = get_bool_env_var("LAUNCH_CLI_UPDATE_CHECK", False)
+UPDATE_ALLOW_PRERELEASE = get_bool_env_var("LAUNCH_CLI_UPDATE_ALLOW_PRERELEASE", False)

--- a/launch/github/auth.py
+++ b/launch/github/auth.py
@@ -2,7 +2,7 @@ import logging
 import os
 from functools import cache
 
-from github import Auth, Github
+from github import Auth, Consts, Github
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +22,17 @@ def github_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {read_github_token()}"}
 
 
-def get_github_instance(token: str | None = None) -> Github:
+def get_github_instance(token: str | None = None, timeout: int | None = None) -> Github:
+    if timeout is None:
+        timeout = Consts.DEFAULT_TIMEOUT
     if not token:
         logger.debug("Token wasn't passed, reading from environment.")
         token = read_github_token()
     auth = Auth.Token(token)
-    return Github(auth=auth)
+    return Github(auth=auth, timeout=timeout)
+
+
+def get_anonymous_github_instance(timeout: int | None = None) -> Github:
+    if timeout is None:
+        timeout = Consts.DEFAULT_TIMEOUT
+    return Github(auth=None, timeout=timeout)

--- a/launch/github/tags.py
+++ b/launch/github/tags.py
@@ -1,0 +1,31 @@
+import itertools
+import logging
+
+from github.Repository import Repository
+from github.Tag import Tag
+from semver import Version
+
+logger = logging.getLogger(__name__)
+
+
+def get_repo_tags(repo: Repository) -> list[Tag]:
+    tags = [tag for tag in repo.get_tags()]
+    logger.debug(f"Fetched {len(tags)} tags from {repo.name}")
+    return tags
+
+
+def get_repo_semantic_versions(repo: Repository) -> list[Version]:
+    def try_parse_version(tag_name: str) -> Version | None:
+        try:
+            return Version.parse(version=tag_name)
+        except Exception as e:
+            logger.debug(f"Failed to parse version from tag {tag_name}: {e}")
+
+    tags = get_repo_tags(repo=repo)
+    versions = list(
+        itertools.filterfalse(
+            lambda x: x is None, [try_parse_version(t.name) for t in tags]
+        )
+    )
+    logger.debug(f"Successfully parsed {len(versions)} from tags on {repo.name}")
+    return versions

--- a/launch/update.py
+++ b/launch/update.py
@@ -1,0 +1,54 @@
+import logging
+
+from semver import Version
+
+from launch import GITHUB_ORG_NAME, GITHUB_REPO_NAME, SEMANTIC_VERSION
+from launch.github.auth import get_anonymous_github_instance
+from launch.github.tags import get_repo_semantic_versions
+
+logger = logging.getLogger(__name__)
+
+
+def latest_version(
+    versions: list[Version], include_prerelease: bool = False
+) -> Version | None:
+    """Narrow a list of versions down to a version that is newer than our current version, if possible. If the current version
+    is supplied in the versions list, it will be treated as if it's an older version (not returned), so that we don't prompt a
+    user to update to the version they're currently running. Prerelease versions are considered only if include_prerelease is set.
+
+    Args:
+        versions (list[Version]): List of versions that are available.
+        include_prerelease (bool, optional): Allow prerelease versions to be returned. Defaults to False.
+
+    Returns:
+        Version | None: The latest Version object, or None if no newer versions exist.
+    """
+    current_version = SEMANTIC_VERSION
+    if not include_prerelease:
+        versions = [v for v in versions if v.prerelease is None]
+    greater_versions = [v for v in versions if v > current_version]
+    if greater_versions:
+        return max(greater_versions)
+
+
+def check_for_updates(include_prerelease: bool = False) -> Version | None:
+    """Checks the repository where this tool lives to see if any new versions are available.
+
+    Args:
+        include_prerelease (bool, optional): Include prerelease versions in the version search. Defaults to False.
+
+    Returns:
+        Version | None: If there's an update available, returns a Version, otherwise None.
+    """
+    try:
+        # Very short timeout to limit the amount of time we spend on this if there's problems on the GitHub side.
+        g = get_anonymous_github_instance(timeout=1)
+        repo = g.get_repo(full_name_or_id=f"{GITHUB_ORG_NAME}/{GITHUB_REPO_NAME}")
+        available_versions = get_repo_semantic_versions(repo=repo)
+        return latest_version(
+            versions=available_versions, include_prerelease=include_prerelease
+        )
+    except Exception as e:
+        # If anything goes wrong, we'll just skip the update check and log to debug
+        logger.debug(f"Failure during check_for_updates: {e}")
+        pass

--- a/tests/unit/github/test_tags.py
+++ b/tests/unit/github/test_tags.py
@@ -1,0 +1,59 @@
+import logging
+
+import pytest
+from semver import Version
+
+from launch.github import tags
+
+
+@pytest.fixture
+def mocked_tags(mocker):
+    semantic_tag = mocker.MagicMock()
+    semantic_tag.name = "1.2.3"
+
+    semantic_prerelease_tag = mocker.MagicMock()
+    semantic_prerelease_tag.name = "1.2.3-alpha"
+
+    bare_tag = mocker.MagicMock()
+    bare_tag.name = "foo"
+
+    slash_tag = mocker.MagicMock()
+    slash_tag.name = "tag/with/slashes"
+
+    dash_tag = mocker.MagicMock()
+    dash_tag.name = "hello-world"
+    yield [semantic_tag, semantic_prerelease_tag, bare_tag, slash_tag, dash_tag]
+
+
+def test_get_repo_tags_includes_non_semantic_versions(mocked_tags, caplog, mocker):
+    expected_tags = mocked_tags
+
+    mocked_repo = mocker.MagicMock()
+    mocked_repo.name = "mocked_repo"
+    mocked_repo.get_tags.return_value = mocked_tags
+
+    with caplog.at_level(logging.DEBUG):
+        returned_tags = tags.get_repo_tags(repo=mocked_repo)
+        assert (
+            f"Fetched {len(expected_tags)} tags from {mocked_repo.name}" in caplog.text
+        )
+        assert returned_tags == expected_tags
+
+
+def test_get_repo_semantic_versions_drops_non_semantic(mocked_tags, caplog, mocker):
+    input_tags = mocked_tags
+    expected_tags = [Version(1, 2, 3), Version(1, 2, 3, "alpha")]
+
+    mocked_repo = mocker.MagicMock()
+    mocked_repo.name = "mocked_repo"
+    mocked_repo.get_tags.return_value = input_tags
+
+    with caplog.at_level(logging.DEBUG):
+        returned_tags = tags.get_repo_semantic_versions(repo=mocked_repo)
+        assert f"Fetched {len(input_tags)} tags from {mocked_repo.name}" in caplog.text
+        assert "foo is not valid SemVer string" in caplog.text
+        assert (
+            f"Successfully parsed {len(expected_tags)} from tags on {mocked_repo.name}"
+            in caplog.text
+        )
+        assert all([r in expected_tags for r in returned_tags])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,13 +1,15 @@
 import pathlib
 
-from launch.cli.entrypoint import cli
+import pytest
+
+from launch.cli import entrypoint
 from launch.cli.github.access.commands import set_default
 from launch.cli.github.hooks.commands import create
 from launch.cli.github.version.commands import apply, predict
 
 
 def test_cli_help(cli_runner):
-    result = cli_runner.invoke(cli, "--help")
+    result = cli_runner.invoke(entrypoint.cli, "--help")
     assert "Launch CLI" in result.output
     assert not result.exception
 
@@ -80,3 +82,41 @@ def test_github_version_apply_tag_exists_exit_code(cli_runner, example_github_re
         f"--repo-path {example_github_repo.working_dir} --source-branch feature/foo",
     )
     assert result.exit_code == 2
+
+
+def test_cli_update_general_env_var_not_set(cli_runner, mocker):
+    mock = mocker.patch.object(entrypoint, "check_for_updates", return_value=None)
+    result = cli_runner.invoke(entrypoint.cli, ["github", "--help"])
+    assert "Command family for GitHub-related tasks." in result.output
+    assert not result.exception
+    mock.assert_not_called()
+
+
+# The presence of this variable, not its value, determines whether or not we perform the update check. Even falsy values trigger a check!
+@pytest.mark.parametrize("env_var_value", ["0", "1", "false", "true", "foo"])
+def test_cli_update_general_env_var_set(env_var_value, cli_runner, mocker):
+    # In this context, this call should remain mocked since it would otherwise reach out to GitHub and can induce rate limiting!
+    mock = mocker.patch.object(entrypoint, "check_for_updates", return_value=None)
+    result = cli_runner.invoke(
+        entrypoint.cli,
+        ["github", "--help"],
+        env={"LAUNCH_CLI_CHECK_UPDATES": env_var_value},
+    )
+    assert "Command family for GitHub-related tasks." in result.output
+    assert not result.exception
+    mock.assert_called_once()
+
+
+@pytest.mark.skip(
+    "TODO: Figure out how Aaron is doing his pipeline mocks and perform the same operations here."
+)
+def test_cli_update_pipeline_env_var_not_set():
+    pass
+
+
+@pytest.mark.skip(
+    "TODO: Figure out how Aaron is doing his pipeline mocks and perform the same operations here."
+)
+@pytest.mark.parametrize("env_var_value", ["0", "1", "false", "true", "foo"])
+def test_cli_update_pipeline_env_var_set(env_var_value):
+    pass

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -85,26 +85,26 @@ def test_github_version_apply_tag_exists_exit_code(cli_runner, example_github_re
 
 
 def test_cli_update_general_env_var_not_set(cli_runner, mocker):
-    mock = mocker.patch.object(entrypoint, "check_for_updates", return_value=None)
+    # Mocked since we don't want to reach out to GitHub and potentially induce rate limiting!
+    mocked_update_check = mocker.patch.object(
+        entrypoint, "check_for_updates", return_value=None
+    )
     result = cli_runner.invoke(entrypoint.cli, ["github", "--help"])
     assert "Command family for GitHub-related tasks." in result.output
     assert not result.exception
-    mock.assert_not_called()
+    mocked_update_check.assert_not_called()
 
 
-# The presence of this variable, not its value, determines whether or not we perform the update check. Even falsy values trigger a check!
-@pytest.mark.parametrize("env_var_value", ["0", "1", "false", "true", "foo"])
-def test_cli_update_general_env_var_set(env_var_value, cli_runner, mocker):
-    # In this context, this call should remain mocked since it would otherwise reach out to GitHub and can induce rate limiting!
-    mock = mocker.patch.object(entrypoint, "check_for_updates", return_value=None)
-    result = cli_runner.invoke(
-        entrypoint.cli,
-        ["github", "--help"],
-        env={"LAUNCH_CLI_CHECK_UPDATES": env_var_value},
+def test_cli_update_general_env_var_set(cli_runner, mocker):
+    # Mocked since we don't want to reach out to GitHub and potentially induce rate limiting!
+    mocker.patch("launch.cli.entrypoint.UPDATE_CHECK", new=True)
+    mocked_update_check = mocker.patch.object(
+        entrypoint, "check_for_updates", return_value=None
     )
+    result = cli_runner.invoke(entrypoint.cli, ["github", "--help"])
     assert "Command family for GitHub-related tasks." in result.output
     assert not result.exception
-    mock.assert_called_once()
+    mocked_update_check.assert_called_once()
 
 
 @pytest.mark.skip(

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -1,0 +1,56 @@
+from contextlib import ExitStack as does_not_raise
+from functools import partial
+from random import randint
+
+import pytest
+
+from launch import env
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_return, raises",
+    [
+        ("y", True, does_not_raise()),
+        ("Y", True, does_not_raise()),
+        ("yes", True, does_not_raise()),
+        ("t", True, does_not_raise()),
+        ("True", True, does_not_raise()),
+        ("ON", True, does_not_raise()),
+        ("1", True, does_not_raise()),
+        ("n", False, does_not_raise()),
+        ("N", False, does_not_raise()),
+        ("no", False, does_not_raise()),
+        ("f", False, does_not_raise()),
+        ("False", False, does_not_raise()),
+        ("ofF", False, does_not_raise()),
+        ("0", False, does_not_raise()),
+        ("yep", None, pytest.raises(ValueError)),
+        ("yeah", None, pytest.raises(ValueError)),
+        ("nope", None, pytest.raises(ValueError)),
+        ("219", None, pytest.raises(ValueError)),
+        ("$", None, pytest.raises(ValueError)),
+    ],
+)
+def test_strtobool(input_value, expected_return, raises):
+    with raises:
+        assert env.strtobool(input_value) == expected_return
+
+
+@pytest.mark.parametrize(
+    "variable_name, variable_value, expected_value",
+    [("LAUNCH_EXAMPLE_TRUE", "1", True), ("LAUNCH_EXAMPLE_FALSE", "0", False)],
+)
+def test_get_bool_env_var(variable_name, variable_value, expected_value, mocker):
+    mocker.patch.object(env.os.environ, "get", return_value=variable_value)
+    assert (
+        env.get_bool_env_var(variable_name, default_value=not expected_value)
+        == expected_value
+    )
+
+
+def test_get_bool_env_var_not_exists():
+    """Mocking out an env var that doesn't exist is a pain, so we'll just choose a random number between a million and a billion and hope nobody has set that var on their system."""
+    assert (
+        env.get_bool_env_var(str(randint(1000000, 1000000000)), default_value=True)
+        == True
+    )

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,185 @@
+from semver import Version
+
+from launch import update
+
+
+def test_check_updates_instance_failure(mocker):
+    mocked_get_anonymous_github_instance = mocker.patch.object(
+        update,
+        "get_anonymous_github_instance",
+        side_effect=Exception("Failed to connect to GitHub"),
+    )
+    mocked_get_repo_semantic_versions = mocker.patch.object(
+        update, "get_repo_semantic_versions"
+    )
+    assert update.check_for_updates() is None
+    mocked_get_anonymous_github_instance.assert_called_once()
+    # If we encounter a failure in retrieving data from GitHub before the stage where we ask for versions, we shouldn't try to get the available versions
+    mocked_get_repo_semantic_versions.assert_not_called()
+
+
+def test_check_for_updates_repo_failure(mocker):
+    class FakeInstance:
+        def get_repo(full_name_or_id: str):
+            raise Exception("Organization or repository name lookup failure")
+
+    mocked_get_anonymous_github_instance = mocker.patch.object(
+        update, "get_anonymous_github_instance", return_value=FakeInstance()
+    )
+    mocked_get_repo_semantic_versions = mocker.patch.object(
+        update, "get_repo_semantic_versions"
+    )
+    assert update.check_for_updates() is None
+    mocked_get_anonymous_github_instance.assert_called_once()
+    # If we encounter a failure in retrieving data from GitHub before the stage where we ask for versions, we shouldn't try to get the available versions
+    mocked_get_repo_semantic_versions.assert_not_called()
+
+
+def test_check_for_updates_versions_failure(mocker):
+    mocked_get_anonymous_github_instance = mocker.patch.object(
+        update, "get_anonymous_github_instance"
+    )
+    mocked_get_repo_semantic_versions = mocker.patch.object(
+        update,
+        "get_repo_semantic_versions",
+        side_effect=Exception(
+            "Something went horribly wrong, this code shouldn't raise"
+        ),
+    )
+    assert update.check_for_updates() is None
+    # Successful calls to retrieve the instance, and then to call the get_repo on the instance
+    assert len(mocked_get_anonymous_github_instance.mock_calls) == 2
+    mocked_get_repo_semantic_versions.assert_called_once()
+
+
+def test_check_for_updates_passes_prerelease_var(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    prerelease_version = Version(1, 2, 4, "prerelease")
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    mocker.patch.object(
+        update,
+        "get_repo_semantic_versions",
+        return_value=[older_version, current_version, prerelease_version],
+    )
+    mocker.patch.object(update, "get_anonymous_github_instance")
+    # There are two versions newer than our current, older version, but only the latest should be returned.
+    assert update.check_for_updates(include_prerelease=False) == None
+    assert update.check_for_updates(include_prerelease=True) == prerelease_version
+
+
+def test_check_for_updates_no_newer_version(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    mocker.patch.object(
+        update,
+        "get_repo_semantic_versions",
+        return_value=[older_version, current_version],
+    )
+    mocker.patch.object(update, "get_anonymous_github_instance")
+    # Since our current version is latest, we expect None to be returned since there is no update to perform.
+    assert update.check_for_updates() == None
+
+
+def test_check_for_updates_one_newer_version(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    latest_version = Version(1, 2, 4)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    mocker.patch.object(
+        update,
+        "get_repo_semantic_versions",
+        return_value=[older_version, current_version, latest_version],
+    )
+    mocker.patch.object(update, "get_anonymous_github_instance")
+    assert update.check_for_updates() == latest_version
+
+
+def test_check_for_updates_newest_version(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    latest_version = Version(1, 2, 4)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=older_version)
+    mocker.patch.object(
+        update,
+        "get_repo_semantic_versions",
+        return_value=[older_version, current_version, latest_version],
+    )
+    mocker.patch.object(update, "get_anonymous_github_instance")
+    assert update.check_for_updates() == latest_version
+
+
+def test_latest_version_no_prerelease(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    latest_version = Version(1, 2, 4)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=older_version)
+    result = update.latest_version(
+        versions=[older_version, current_version, latest_version]
+    )
+    assert result == latest_version
+
+
+def test_latest_version_no_current_match(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(versions=[older_version])
+    assert result == None
+
+
+def test_latest_version_current_is_latest(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(versions=[older_version, current_version])
+    assert result == None
+
+
+def test_latest_version_prerelease_ignored_when_include_is_not_set(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    current_prerelease = Version(1, 2, 4, "alpha-1")
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(
+        include_prerelease=False,
+        versions=[older_version, current_version, current_prerelease],
+    )
+    assert result == None
+
+
+def test_latest_version_current_prerelease_is_not_newer(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    current_prerelease = Version(1, 2, 3, "alpha-1")
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(
+        include_prerelease=True,
+        versions=[older_version, current_version, current_prerelease],
+    )
+    assert result == None
+
+
+def test_latest_version_later_prerelease_is_not_newer_when_include_not_set(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    newer_prerelease = Version(1, 2, 4, "alpha-1")
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(
+        include_prerelease=False,
+        versions=[older_version, current_version, newer_prerelease],
+    )
+    assert result == None
+
+
+def test_latest_version_later_prerelease_is_newer_when_include_set(mocker):
+    older_version = Version(1, 2, 2)
+    current_version = Version(1, 2, 3)
+    newer_prerelease = Version(1, 2, 4, "alpha-1")
+    mocker.patch.object(update, "SEMANTIC_VERSION", new=current_version)
+    result = update.latest_version(
+        include_prerelease=True,
+        versions=[older_version, current_version, newer_prerelease],
+    )
+    assert result == newer_prerelease


### PR DESCRIPTION
Adds opt-in version checking to the CLI commands. 

Users may opt-in to have `launch-cli` automatically check their version with the following environment variable:

```sh
export LAUNCH_CLI_UPDATE_CHECK=true
```

By default, only semantic versions greater than the current version (defined in `launch/__input__.py`) will create a notification on the CLI prior to whatever output is expected for subsequent command families. If desired, users may opt-in to prerelease notifications by setting the following:

```sh
export LAUNCH_CLI_UPDATE_ALLOW_PRERELEASE=true
```

Users may disable this functionality by setting these variables to `false` or unsetting them entirely.

Versions are pulled from this repository's tags by making a GitHub API call, which may not be desirable in all scenarios. For example, pipeline execution of `launch-cli` should never check for new versions; pipelines may not even have outbound internet access to do so! If a pipeline command is executed, the version check is always skipped. Additionally, a short timeout (1 second) is configured to limit impacts when GItHub APIs are in a degraded state. If an update check fails for any reason, it is logged to the debug level and is only visible when supplying the `--verbose` flag to the `launch` command -- users are never notified as these errors are not actionable, and shouldn't block execution of further steps that do not rely on GitHub.

Additionally, the current version of the software can be now be output using either `launch --version` or `launch version`.

Automatic version updates to the installed tool are not in scope for this feature, nor are automated version bumps in code. When it comes time to cut a new version of the `launch-cli` tool, an engineer will need to manually update the current version in the `launch/__input__.py` file, tag the release once merged to main, and then use GitHub's release mechanism to truly "release" the version to PyPI. While it may be possible to automate some of this toil down the road, getting it right is nontrivial and will need further work performed once we migrate off GitHub actions onto our own pipelines.
