### PR TITLE
removing check from subprocess

### DIFF
--- a/src/launch/automation/common/functions.py
+++ b/src/launch/automation/common/functions.py
@@ -123,9 +123,9 @@ def install_tool_versions(file: str) -> None:
 
         for line in lines:
             plugin = line.split()[0]
-            subprocess.run(["asdf", "plugin", "add", plugin], check=True)
+            subprocess.run(["asdf", "plugin", "add", plugin])
 
-        subprocess.run(["asdf", "install"], check=True)
+        subprocess.run(["asdf", "install"])
     except Exception as e:
         raise RuntimeError(
             f"An error occurred with asdf install {file}: {str(e)}"

--- a/test/unit/automation/common/test_install_tool_versions.py
+++ b/test/unit/automation/common/test_install_tool_versions.py
@@ -14,9 +14,9 @@ def test_install_tool_versions_success(mocker):
 
     mock_run.assert_has_calls(
         [
-            mocker.call(["asdf", "plugin", "add", "tool1"], check=True),
-            mocker.call(["asdf", "plugin", "add", "tool2"], check=True),
-            mocker.call(["asdf", "install"], check=True),
+            mocker.call(["asdf", "plugin", "add", "tool1"]),
+            mocker.call(["asdf", "plugin", "add", "tool2"]),
+            mocker.call(["asdf", "install"]),
         ]
     )
 


### PR DESCRIPTION
- There is an issue in MacOS that when this returns non-zero, it will completely exit the script instead of a `break` type behavior. Removing this check. 